### PR TITLE
Added Chocolatey Install Instructions

### DIFF
--- a/web/content/110.docs.folder/001.install.folder/001.windows-installation.article/@body.md
+++ b/web/content/110.docs.folder/001.install.folder/001.windows-installation.article/@body.md
@@ -10,6 +10,7 @@ If you use AuthPass for Windows please provide feedback. Thanks!
 
 * Download the latest version: [![AuthPass-setup-stable.exe](https://data.authpass.app/data/artifact.download/AuthPass-setup-stable.exe/shield)](https://data.authpass.app/data/artifact.download/AuthPass-setup-stable.exe)
 * Mirror: [available on FossHub](https://www.fosshub.com/AuthPass.html)
+* Install via [Chocolatey](https://chocolatey.org/packages/authpass) `choco install authpass`
 
 !!! hint "Keep up to date"
    AuthPass is updated regularly. Please check regularly for updates.


### PR DESCRIPTION
A package was requested [here](https://github.com/authpass/authpass/issues/117). I created/ published one. I highly recommend waiting on approval before actually adding this to documentation. As it stands, the only way to install it is with the explicit version `choco install authpass --version x.x.x` once it is approved, the instructions I added will be valid.